### PR TITLE
Added uri to type definition

### DIFF
--- a/lib/json1.js
+++ b/lib/json1.js
@@ -40,6 +40,7 @@ let debugMode = false
 
 const type = exports.type = {
   name: 'json1',
+  uri: "http://sharejs.org/types/JSONv1",
   readCursor,
   writeCursor,
 


### PR DESCRIPTION
This fixes an issue I discovered in which the normalizeType function will return undefined as a result of the json1 type missing a uri.

`// Takes in a string (type name or URI) and returns the normalized name (uri)
exports.normalizeType = function(typeName) {
  return types[typeName] && types[typeName].uri;
};`

I was not sure if sharejs.org is still being used so please change if need be.