### PR TITLE
Proposal – Add support for presences

### DIFF
--- a/lib/json1.ts
+++ b/lib/json1.ts
@@ -20,8 +20,8 @@
 // import log from './log'
 import deepEqual from './deepEqual.js'
 import deepClone from './deepClone.js'
-import {ReadCursor, WriteCursor, readCursor, writeCursor, advancer, eachChildOf, isValidPathItem} from './cursor.js'
-import { Doc, JSONOpComponent, Path, Key, JSONOp, JSONOpList, Conflict, ConflictType } from './types.js'
+import { ReadCursor, WriteCursor, readCursor, writeCursor, advancer, eachChildOf, isValidPathItem } from './cursor.js'
+import { Doc, JSONOpComponent, Path, Presence, Key, JSONOp, JSONOpList, Conflict, ConflictType } from './types.js'
 
 const RELEASE_MODE = process.env.JSON1_RELEASE_MODE
 const log: (...args: any) => void = RELEASE_MODE ? (() => {}) : require('./log').default
@@ -57,6 +57,7 @@ export const type = {
 
   apply,
   transformPosition,
+  transformPresence,
   compose,
   tryTransform,
   transform,
@@ -688,7 +689,11 @@ function transformPosition(path: Path, op: JSONOp): Path | null {
       if (et) {
         const e = getEdit(c!)
         log('Embedded edit', e, et)
-        if (et.transformPosition) path[i] = et.transformPosition(path[i], e)
+        if (et.transformPosition) {
+            path[i] = et.transformPosition(path[i], e)
+        } else if (et.transformCursor) {
+            path[i] = et.transformCursor(path[i], e)
+        }
         // Its invalid for the operation to have drops inside the embedded edit here.
         break
       }
@@ -719,6 +724,25 @@ function transformPosition(path: Path, op: JSONOp): Path | null {
 
   log('-> transformPosition returning', path)
   return path
+}
+
+function transformPresence(presence: Presence | null, op: JSONOp, isOwnOperation: boolean): Presence | null {
+    if (!presence || !presence.start || !presence.end) {
+        return null
+    }
+
+    const start = transformPosition(presence.start, op)
+    const end = transformPosition(presence.end, op)
+
+    if (start && end) {
+        return { start, end }
+    } else if (start) {
+        return { start, end: start }
+    } else if (end) {
+        return { start: end, end }
+    }
+
+    return null
 }
 
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -57,6 +57,10 @@ export type JSONOp = null | JSONOpList
 
 export type Key = number | string
 export type Path = Key[]
+export type Presence = {
+    start: Path,
+    end: Path,
+}
 
 /**
  * JSON documents must be able to round-trip through JSON.stringify /

--- a/package-lock.json
+++ b/package-lock.json
@@ -297,6 +297,12 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -525,6 +531,18 @@
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "dev": true
+    },
     "log-symbols": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
@@ -721,6 +739,17 @@
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
     },
+    "quill-delta": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-4.2.2.tgz",
+      "integrity": "sha512-qjbn82b/yJzOjstBgkhtBjN2TNK+ZHP/BgUQO+j6bRhWQQdmj2lH6hXG7+nwwLF41Xgn//7/83lxs9n2BkTtTg==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "1.2.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.isequal": "^4.5.0"
+      }
+    },
     "readdirp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
@@ -741,6 +770,15 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
+    },
+    "rich-text": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/rich-text/-/rich-text-4.1.0.tgz",
+      "integrity": "sha512-zQg80us6AfopS7s2YPsU+jfLX1RJaOdd6w26Jz4Al1G73AMzqDLTIZSnr0I7HTdCIU1gcGSMDlhq2v4IfoKfbg==",
+      "dev": true,
+      "requires": {
+        "quill-delta": "^4.2.1"
+      }
     },
     "seedrandom": {
       "version": "2.4.4",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "mocha": "^7.1.1",
     "ot-fuzzer": "1.3",
     "ot-simple": "^1.0.0",
+    "rich-text": "^4.1.0",
     "terser": "^4.6.7",
     "typescript": "^3.9.5"
   },

--- a/test/presence.js
+++ b/test/presence.js
@@ -1,0 +1,86 @@
+const assert = require("assert");
+const Delta = require("quill-delta");
+const { type } = require("../dist/json1.release");
+
+type.registerSubtype(require("rich-text"));
+
+describe("presences", () => {
+  it("transforms json1 only presences", () => {
+    const op = ["z", 0, { i: "hello" }];
+    const presenceBefore = { start: ["z", 0], end: ["z", 1] };
+    const presenceAfter = { start: ["z", 1], end: ["z", 2] };
+
+    assert.deepStrictEqual(
+      type.transformPresence(presenceBefore, op),
+      presenceAfter
+    );
+  });
+
+  it("transforms json1 + text-unicode presences", () => {
+    const op = ["z", [0, { i: "hello" }], [2, { es: ["hi"] }]];
+    const presenceBefore = { start: ["z", 1, 1], end: ["z", 2, 0] };
+    const presenceAfter = { start: ["z", 2, 3], end: ["z", 3, 0] };
+
+    assert.deepStrictEqual(
+      type.transformPresence(presenceBefore, op),
+      presenceAfter
+    );
+  });
+
+  it("transforms json1 + rich-text presences", () => {
+    const op = [
+      "z",
+      [0, { i: "hello" }],
+      [4, { et: "rich-text", e: new Delta([{ insert: "bye" }]) }],
+    ];
+    const presenceBefore = { start: ["z", 3, 1], end: ["z", 4, 0] };
+    const presenceAfter = { start: ["z", 4, 4], end: ["z", 5, 0] };
+
+    assert.deepStrictEqual(
+      type.transformPresence(presenceBefore, op),
+      presenceAfter
+    );
+  });
+
+  it("does nothing on null presences", () => {
+    const op = ["z", 0, { i: "hello" }];
+
+    assert.deepStrictEqual(type.transformPresence(null, op), null);
+  });
+
+  it("returns null on missing start or end", () => {
+    const op = ["z", 0, { i: "hello" }];
+
+    assert.deepStrictEqual(
+      type.transformPresence({ start: null, end: [] }, op),
+      null
+    );
+
+    assert.deepStrictEqual(
+      type.transformPresence({ start: [], end: null }, op),
+      null
+    );
+  });
+
+  it("returns collapsed presence when start container is removed", () => {
+    const op = ["z", 0, { r: true }];
+    const presenceBefore = { start: ["z", 0], end: ["z", 1] };
+    const presenceAfter = { start: ["z", 0], end: ["z", 0] };
+
+    assert.deepStrictEqual(
+      type.transformPresence(presenceBefore, op),
+      presenceAfter
+    );
+  });
+
+  it("returns collapsed presence when end container is removed", () => {
+    const op = ["z", 1, { r: true }];
+    const presenceBefore = { start: ["z", 0], end: ["z", 1] };
+    const presenceAfter = { start: ["z", 0], end: ["z", 0] };
+
+    assert.deepStrictEqual(
+      type.transformPresence(presenceBefore, op),
+      presenceAfter
+    );
+  });
+});


### PR DESCRIPTION
Hello 👋  As stated in #9, ShareDB "recently" introduced presences in  https://github.com/share/sharedb/pull/322 

The shape of the presence object is up to the OT type to define. So I propose a very simple one:
```
type Presence = {
  start: Path,
  end: Path,
}
```

This pull request propose this type and the following `transformPresence` implementation. This internally calls `transformPosition` for each end of the presence, and fallbacks on the `transformPosition` or `transformCursor` of the leaf subtypes if needed. There is a few examples in the tests for a better understanding.

We could also consider shortening the keys to match the size saving effect used by operations.

Let me know what you think!