### PR TITLE
Fix Doc type to allow interfaces

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -68,7 +68,7 @@ export type Path = Key[]
  * - Functions
  * - Sets, Maps, Dates, DOM nodes, etc
  */
-export type Doc = null | boolean | number | string | Doc[] | {[k: string]: Doc}
+export type Doc = null | boolean | number | string | Doc[] | Record<string, Doc>
 
 export enum ConflictType {
   RM_UNEXPECTED_CONTENT = 1,


### PR DESCRIPTION
The current type definition for Doc doesn't allow simple interfaces such as:

```typescript
interface Foo {
    a: string,
}
```

Expanding the type definition to a `Record` type fixes this and greatly improves useability with Typescript.